### PR TITLE
Adds traits from race to endpoint

### DIFF
--- a/api/srd/backgroundAPI.go
+++ b/api/srd/backgroundAPI.go
@@ -30,7 +30,9 @@ func GetRaces(w http.ResponseWriter, r *http.Request) {
 	for _, i := range racesInterface {
 		raceMap := i.(map[string]interface{})
 		speed := raceMap["speed"].(map[string]interface{})
-		races = append(races, models.Race{raceMap["name"].(string), int(speed["walk"].(float64))})
+		race := models.Race{Name: raceMap["name"].(string), Speed: int(speed["walk"].(float64))}
+		race.ParseTraits(raceMap["traits"].(string))
+		races = append(races, race)
 	}
 
 	bytes, _ := json.Marshal(races)

--- a/api/srd/backgroundAPI.go
+++ b/api/srd/backgroundAPI.go
@@ -31,7 +31,7 @@ func GetRaces(w http.ResponseWriter, r *http.Request) {
 		raceMap := i.(map[string]interface{})
 		speed := raceMap["speed"].(map[string]interface{})
 		race := models.Race{Name: raceMap["name"].(string), Speed: int(speed["walk"].(float64))}
-		race.ParseTraits(raceMap["traits"].(string))
+		race.ParseTraits(raceMap["traits"].(string), raceMap["vision"].(string))
 		races = append(races, race)
 	}
 

--- a/models/background.go
+++ b/models/background.go
@@ -1,12 +1,19 @@
 package models
 
 import (
+	"fmt"
 	"strings"
 )
 
 type Race struct {
-	Name  string `json:"name"`
-	Speed int    `json:"speed"`
+	Name   string        `json:"name"`
+	Speed  int           `json:"speed"`
+	Traits []TraitValues `json:"traits"`
+}
+
+type TraitValues struct {
+	Name string `json:"name"`
+	Desc string `json:"desc"`
 }
 
 type Class struct {
@@ -17,6 +24,22 @@ type Class struct {
 	ProWeapons   string              `json:"prof_weapons"`
 	Information  map[string][]string `json:"info"`
 	Table        string              `json:"table,omitempty" firestore:"-"`
+}
+
+func (r *Race) ParseTraits(rawTraits string) {
+	fmt.Println(r.Name)
+	traitStrings := strings.Split(rawTraits, "**_")
+	for _, s := range traitStrings {
+		vals := strings.Split(s, "._**")
+		if len(vals) == 2 {
+			r.Traits = append(r.Traits, TraitValues{Name: vals[0], Desc: strings.Trim(vals[1], " *\n")})
+		} else if len(vals) == 1 {
+			vals := strings.Split(s, "** ")
+			if len(vals) == 2 {
+				r.Traits = append(r.Traits, TraitValues{Name: strings.Trim(vals[0], " *\n"), Desc: strings.Trim(vals[1], " *\n")})
+			}
+		}
+	}
 }
 
 func (c *Class) ParseTable() {


### PR DESCRIPTION
Fixes #17 
Adds vision and other traits to the Races endpoint.

```
[
{
"name": "Dwarf",
"speed": 25,
"traits": [
{
"name": "Darkvision",
"desc": "Accustomed to life underground, you have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can’t discern color in darkness, only shades of gray."
},
{
"name": "Dwarven Resilience",
"desc": "You have advantage on saving throws against poison, and you have resistance against poison damage."
},
{
"name": "Dwarven Combat Training",
"desc": "You have proficiency with the battleaxe, handaxe, light hammer, and warhammer."
},
{
"name": "Tool Proficiency",
"desc": "You gain proficiency with the artisan’s tools of your choice: smith’s tools, brewer’s supplies, or mason’s tools."
},
{
"name": "Stonecunning",
"desc": "Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus to the check, instead of your normal proficiency bonus."
}
]
},
...```